### PR TITLE
[POC] Shared-library plugin system for custom SPARQL IRI functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,9 +510,35 @@ if (NOT _EMSCRIPTEN_NO_INDEXBUILDER_AND_SERVER)
 
     add_executable(qlever-server src/ServerMain.cpp)
     qlever_target_link_libraries(qlever-server engine server ${CMAKE_THREAD_LIBS_INIT} Boost::program_options compilationInfo global)
+    # Export symbols so that dynamically loaded plugins can resolve them.
+    set_target_properties(qlever-server PROPERTIES ENABLE_EXPORTS ON)
     if (USE_PRECOMPILED_HEADERS)
         target_precompile_headers(qlever-server REUSE_FROM engine)
     endif()
+endif()
+
+option(BUILD_EXAMPLE_PLUGINS "Build example plugins for the custom function API" OFF)
+if(BUILD_EXAMPLE_PLUGINS)
+    add_library(example_plugin SHARED examples/ExamplePlugin.cpp)
+    # Plugins resolve symbols at runtime from the host process (qlever-server),
+    # so we only need the include paths for compilation, not the actual libraries.
+    # Get all transitive include directories from sparqlExpressions.
+    get_target_property(_SPARQL_EXPR_INCLUDES sparqlExpressions INCLUDE_DIRECTORIES)
+    get_target_property(_SPARQL_EXPR_IFACE_INCLUDES sparqlExpressions INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(example_plugin PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_SOURCE_DIR}/src/parser
+        "$<TARGET_PROPERTY:sparqlExpressions,INCLUDE_DIRECTORIES>"
+        "$<TARGET_PROPERTY:sparqlExpressions,INTERFACE_INCLUDE_DIRECTORIES>")
+    # Inherit compile definitions and features but do not link.
+    target_compile_definitions(example_plugin PRIVATE
+        "$<TARGET_PROPERTY:sparqlExpressions,INTERFACE_COMPILE_DEFINITIONS>")
+    set_target_properties(example_plugin PROPERTIES
+        PREFIX ""
+        CXX_STANDARD 23
+        POSITION_INDEPENDENT_CODE ON)
+    # Allow undefined symbols — they resolve from the host process at load time.
+    target_link_options(example_plugin PRIVATE "LINKER:--allow-shlib-undefined")
 endif()
 
 add_executable(LibQLeverExample src/libqlever/LibQLeverExample.cpp)

--- a/examples/ExamplePlugin.cpp
+++ b/examples/ExamplePlugin.cpp
@@ -1,0 +1,98 @@
+// Copyright 2025, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+//
+// Example plugin demonstrating the custom function API.
+//
+// This plugin registers two custom SPARQL functions:
+//
+//   <http://example.org/functions#fortyTwo>()
+//     A nullary function that always returns the integer 42.
+//
+//   <http://example.org/functions#double>(?x)
+//     A unary function that doubles its numeric argument.
+//
+//   <http://wikiba.se/ontology#isSomeValue>(?x)
+//     Equivalent to STRSTARTS(STR(?x),
+//     "http://www.wikidata.org/.well-known/genid/"). Returns true if the value
+//     is a Wikidata "unknown value" blank node.
+//
+// Usage:
+//   qlever-server ... --load-plugin ./example_plugin.so
+//
+//   SELECT (<http://example.org/functions#fortyTwo>() AS ?x) WHERE { }
+//   SELECT (<http://example.org/functions#double>(42) AS ?x) WHERE { }
+//
+// Build (from the qlever build directory):
+//   cmake -DBUILD_EXAMPLE_PLUGINS=ON ..
+//   make example_plugin
+
+#include "engine/sparqlExpressions/NaryExpression.h"
+#include "engine/sparqlExpressions/NaryExpressionImpl.h"
+#include "engine/sparqlExpressions/PluginApi.h"
+
+using namespace sparqlExpression;
+using namespace sparqlExpression::detail;
+
+// --- FortyTwo: nullary function returning 42 ---
+
+// We use a simple IdExpression that always evaluates to the integer 42.
+#include "engine/sparqlExpressions/LiteralExpression.h"
+
+static SparqlExpression* makeFortyTwo(SparqlExpression::Ptr*, int) {
+  return new IdExpression(Id::makeFromInt(42));
+}
+
+// --- Double: unary function that doubles a numeric value ---
+
+// The implementation follows the same pattern as built-in numeric functions
+// (see NumericUnaryExpressions.cpp).
+struct DoubleValueImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    return num * 2;
+  }
+};
+
+using DoubleValue = MakeNumericExpression<DoubleValueImpl>;
+using DoubleExpression = NARY<1, FV<DoubleValue, NumericValueGetter>>;
+
+static SparqlExpression* makeDouble(SparqlExpression::Ptr* args, int) {
+  return new DoubleExpression(std::move(args[0]));
+}
+
+// --- isSomeValue: STRSTARTS(STR(?x),
+// "http://www.wikidata.org/.well-known/genid/") ---
+
+static SparqlExpression* makeIsSomeValue(SparqlExpression::Ptr* args, int) {
+  // STR(?x)
+  auto strExpr = makeStrExpression(std::move(args[0]));
+
+  // Literal for the prefix string.
+  using Literal = ad_utility::triple_component::Literal;
+  auto prefixLit =
+      Literal::literalWithNormalizedContent(asNormalizedStringViewUnsafe(
+          "http://www.wikidata.org/.well-known/genid/"));
+  auto prefixExpr =
+      std::make_unique<StringLiteralExpression>(std::move(prefixLit));
+
+  // STRSTARTS(STR(?x), prefix)
+  return makeStrStartsExpression(std::move(strExpr), std::move(prefixExpr))
+      .release();
+}
+
+// --- Plugin registration ---
+
+static QleverFunctionRegistration registrations[] = {
+    {"http://example.org/functions#fortyTwo", 0, &makeFortyTwo},
+    {"http://example.org/functions#double", 1, &makeDouble},
+    {"http://wikiba.se/ontology#isSomeValue", 1, &makeIsSomeValue},
+};
+
+extern "C" {
+int qlever_plugin_api_version() { return QLEVER_PLUGIN_API_VERSION; }
+
+const QleverFunctionRegistration* qlever_plugin_register(int* count) {
+  *count = sizeof(registrations) / sizeof(registrations[0]);
+  return registrations;
+}
+}

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -13,6 +13,7 @@
 
 #include "CompilationInfo.h"
 #include "engine/Server.h"
+#include "engine/sparqlExpressions/CustomFunctionRegistry.h"
 #include "global/Constants.h"
 #include "global/RuntimeParameters.h"
 #include "util/MemorySize/MemorySize.h"
@@ -54,6 +55,7 @@ int main(int argc, char** argv) {
   bool onlyPsoAndPosPermutations;
   bool persistUpdates;
   std::vector<std::string> preloadMaterializedViews;
+  std::vector<std::string> pluginPaths;
 
   ad_utility::MemorySize memoryMaxSize;
 
@@ -197,6 +199,11 @@ int main(int argc, char** argv) {
       "prefix are rejected. To disable all federated queries, set this option "
       "to an invalid IRI prefix like `-`. Magic services (for example spatial "
       "search or materialized views) are never affected.");
+  add("load-plugin",
+      po::value<std::vector<std::string>>(&pluginPaths)->multitoken(),
+      "Paths to shared library plugins (.so) that provide custom SPARQL "
+      "functions. Multiple plugins can be specified. The server will refuse "
+      "to start if any plugin fails to load.");
   po::variables_map optionsMap;
 
   try {
@@ -220,6 +227,12 @@ int main(int argc, char** argv) {
               << ", compiled on " << qlever::version::DatetimeOfCompilation
               << " using git hash " << qlever::version::GitShortHash << EMPH_OFF
               << std::endl;
+
+  // Load custom function plugins before starting the server.
+  if (!pluginPaths.empty()) {
+    sparqlExpression::CustomFunctionRegistry::instance().loadPlugins(
+        pluginPaths);
+  }
 
   try {
     Server server(port, numSimultaneousQueries, memoryMaxSize,

--- a/src/engine/sparqlExpressions/CMakeLists.txt
+++ b/src/engine/sparqlExpressions/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(sparqlExpressions
         PrefilterExpressionIndex.cpp
         GeoExpression.cpp
         BlankNodeExpression.cpp
-        GroupConcatExpression.cpp)
+        GroupConcatExpression.cpp
+        CustomFunctionRegistry.cpp)
 
-qlever_target_link_libraries(sparqlExpressions util index Boost::url)
+qlever_target_link_libraries(sparqlExpressions util index Boost::url ${CMAKE_DL_LIBS})

--- a/src/engine/sparqlExpressions/CustomFunctionRegistry.cpp
+++ b/src/engine/sparqlExpressions/CustomFunctionRegistry.cpp
@@ -1,0 +1,142 @@
+// Copyright 2025, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+
+#include "engine/sparqlExpressions/CustomFunctionRegistry.h"
+
+#include <dlfcn.h>
+
+#include "engine/sparqlExpressions/PluginApi.h"
+#include "util/Log.h"
+
+namespace sparqlExpression {
+
+// ____________________________________________________________________________
+CustomFunctionRegistry& CustomFunctionRegistry::instance() {
+  static CustomFunctionRegistry registry;
+  return registry;
+}
+
+// ____________________________________________________________________________
+void CustomFunctionRegistry::loadPlugins(
+    const std::vector<std::string>& pluginPaths) {
+  for (const auto& path : pluginPaths) {
+    AD_LOG_INFO << "Loading plugin: " << path << std::endl;
+
+    // Open the shared library.
+    void* handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (!handle) {
+      throw std::runtime_error(
+          absl::StrCat("Failed to load plugin \"", path, "\": ", dlerror()));
+    }
+
+    // Clear any previous error.
+    dlerror();
+
+    // Check API version.
+    auto versionFunc =
+        reinterpret_cast<int (*)()>(dlsym(handle, "qlever_plugin_api_version"));
+    if (!versionFunc) {
+      dlclose(handle);
+      throw std::runtime_error(absl::StrCat(
+          "Plugin \"", path, "\" does not export qlever_plugin_api_version"));
+    }
+    int version = versionFunc();
+    if (version != QLEVER_PLUGIN_API_VERSION) {
+      dlclose(handle);
+      throw std::runtime_error(
+          absl::StrCat("Plugin \"", path, "\" has API version ", version,
+                       ", but expected ", QLEVER_PLUGIN_API_VERSION));
+    }
+
+    // Get the registration function.
+    auto registerFunc =
+        reinterpret_cast<const QleverFunctionRegistration* (*)(int*)>(
+            dlsym(handle, "qlever_plugin_register"));
+    if (!registerFunc) {
+      dlclose(handle);
+      throw std::runtime_error(absl::StrCat(
+          "Plugin \"", path, "\" does not export qlever_plugin_register"));
+    }
+
+    // Get registrations.
+    int count = 0;
+    const QleverFunctionRegistration* regs = registerFunc(&count);
+    if (!regs || count <= 0) {
+      dlclose(handle);
+      throw std::runtime_error(absl::StrCat(
+          "Plugin \"", path, "\" returned no function registrations"));
+    }
+
+    // Register each function.
+    for (int i = 0; i < count; ++i) {
+      const auto& reg = regs[i];
+      if (!reg.fullIri || !reg.factory) {
+        dlclose(handle);
+        throw std::runtime_error(absl::StrCat(
+            "Plugin \"", path, "\" has invalid registration at index ", i));
+      }
+
+      std::string iri(reg.fullIri);
+      int arity = reg.arity;
+      auto rawFactory = reg.factory;
+
+      if (registry_.contains(iri)) {
+        AD_LOG_WARN << "Custom function <" << iri
+                    << "> is being replaced by plugin: " << path << std::endl;
+      }
+
+      Entry entry;
+      entry.fullIri = iri;
+      entry.arity = arity;
+      entry.factory = [rawFactory, arity,
+                       iri](std::vector<SparqlExpression::Ptr> args)
+          -> SparqlExpression::Ptr {
+        AD_CONTRACT_CHECK(static_cast<int>(args.size()) == arity);
+        SparqlExpression* raw = rawFactory(args.data(), arity);
+        if (!raw) {
+          throw std::runtime_error(absl::StrCat("Custom function <", iri,
+                                                "> factory returned nullptr"));
+        }
+        return SparqlExpression::Ptr(raw);
+      };
+
+      registry_.insert_or_assign(std::move(iri), std::move(entry));
+      AD_LOG_INFO << "  Registered custom function: <" << reg.fullIri
+                  << "> (arity " << arity << ")" << std::endl;
+    }
+
+    // Optionally get the cleanup function.
+    auto cleanupFunc =
+        reinterpret_cast<void (*)()>(dlsym(handle, "qlever_plugin_cleanup"));
+
+    loadedPlugins_.push_back(
+        {.handle = handle, .path = path, .cleanup = cleanupFunc});
+  }
+}
+
+// ____________________________________________________________________________
+const CustomFunctionRegistry::Entry* CustomFunctionRegistry::lookup(
+    std::string_view fullIri) const {
+  auto it = registry_.find(std::string(fullIri));
+  if (it != registry_.end()) {
+    return &it->second;
+  }
+  return nullptr;
+}
+
+// ____________________________________________________________________________
+bool CustomFunctionRegistry::empty() const { return registry_.empty(); }
+
+// ____________________________________________________________________________
+CustomFunctionRegistry::~CustomFunctionRegistry() {
+  for (auto& plugin : loadedPlugins_) {
+    if (plugin.cleanup) {
+      plugin.cleanup();
+    }
+    if (plugin.handle) {
+      dlclose(plugin.handle);
+    }
+  }
+}
+
+}  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/CustomFunctionRegistry.h
+++ b/src/engine/sparqlExpressions/CustomFunctionRegistry.h
@@ -1,0 +1,70 @@
+// Copyright 2025, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+
+#ifndef QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_CUSTOMFUNCTIONREGISTRY_H
+#define QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_CUSTOMFUNCTIONREGISTRY_H
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "engine/sparqlExpressions/SparqlExpression.h"
+
+namespace sparqlExpression {
+
+// A singleton registry of custom SPARQL functions loaded from shared-library
+// plugins at server startup. The registry is populated once before any query
+// threads are started, so concurrent reads during query processing are safe
+// without locks.
+class CustomFunctionRegistry {
+ public:
+  // Factory signature: takes a vector of child expressions, returns a new
+  // expression.
+  using FactoryFunction =
+      std::function<SparqlExpression::Ptr(std::vector<SparqlExpression::Ptr>)>;
+
+  // A registered custom function.
+  struct Entry {
+    std::string fullIri;
+    int arity;
+    FactoryFunction factory;
+  };
+
+  // Get the global singleton instance.
+  static CustomFunctionRegistry& instance();
+
+  // Load plugins from the given shared-library paths. Throws on any failure
+  // (missing file, wrong API version, missing symbols, etc.).
+  void loadPlugins(const std::vector<std::string>& pluginPaths);
+
+  // Look up a custom function by its full IRI. Returns nullptr if not found.
+  const Entry* lookup(std::string_view fullIri) const;
+
+  // Return true if the registry contains any custom functions.
+  bool empty() const;
+
+  ~CustomFunctionRegistry();
+
+  // Not copyable or movable (singleton).
+  CustomFunctionRegistry(const CustomFunctionRegistry&) = delete;
+  CustomFunctionRegistry& operator=(const CustomFunctionRegistry&) = delete;
+
+ private:
+  CustomFunctionRegistry() = default;
+
+  // Maps full IRI string -> Entry.
+  std::unordered_map<std::string, Entry> registry_;
+
+  // Keeps loaded shared libraries alive for the lifetime of the process.
+  struct LoadedPlugin {
+    void* handle = nullptr;
+    std::string path;
+    void (*cleanup)() = nullptr;
+  };
+  std::vector<LoadedPlugin> loadedPlugins_;
+};
+
+}  // namespace sparqlExpression
+
+#endif  // QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_CUSTOMFUNCTIONREGISTRY_H

--- a/src/engine/sparqlExpressions/PluginApi.h
+++ b/src/engine/sparqlExpressions/PluginApi.h
@@ -1,0 +1,45 @@
+// Copyright 2025, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+
+#ifndef QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_PLUGINAPI_H
+#define QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_PLUGINAPI_H
+
+#include "engine/sparqlExpressions/SparqlExpression.h"
+
+// Increment this when the plugin ABI changes in an incompatible way.
+#define QLEVER_PLUGIN_API_VERSION 1
+
+// A single function registration entry provided by a plugin.
+struct QleverFunctionRegistration {
+  // Full IRI of the function (without angle brackets),
+  // e.g. "http://example.org/functions#myFunc".
+  const char* fullIri;
+
+  // Number of arguments the function takes (0 = nullary, 1 = unary, etc.).
+  int arity;
+
+  // Factory function. Receives an array of `numArgs` expression pointers
+  // (as `SparqlExpression::Ptr*`, i.e. `std::unique_ptr<SparqlExpression>*`).
+  // The plugin may move out of each element. Returns an owning raw pointer
+  // that the engine wraps in a `unique_ptr`. Using a raw pointer across the
+  // shared-library boundary avoids ABI issues with `std::unique_ptr`.
+  sparqlExpression::SparqlExpression* (*factory)(
+      sparqlExpression::SparqlExpression::Ptr* args, int numArgs);
+};
+
+// Plugins must define the following functions with C linkage:
+//
+//   // Return the API version the plugin was compiled against.
+//   extern "C" int qlever_plugin_api_version();
+//
+//   // Return a pointer to a static array of registrations and set `*count`
+//   // to the number of entries. The engine reads exactly `*count` entries.
+//   extern "C" const QleverFunctionRegistration*
+//       qlever_plugin_register(int* count);
+//
+// Optionally, plugins may also define:
+//
+//   // Called before the shared library is unloaded. Use for cleanup.
+//   extern "C" void qlever_plugin_cleanup();
+
+#endif  // QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_PLUGINAPI_H

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -22,6 +22,7 @@
 #include "engine/SpatialJoinConfig.h"
 #include "engine/sparqlExpressions/BlankNodeExpression.h"
 #include "engine/sparqlExpressions/CountStarExpression.h"
+#include "engine/sparqlExpressions/CustomFunctionRegistry.h"
 #include "engine/sparqlExpressions/ExistsExpression.h"
 #include "engine/sparqlExpressions/GroupConcatExpression.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
@@ -303,6 +304,21 @@ ExpressionPtr Visitor::processIriFunctionCall(
       return createUnary(&makeIsGeoPointExpression);
     } else if (ad_utility::contains(customGeoUnaryFuncs, functionName)) {
       return createUnary(customGeoUnaryFuncs.at(functionName));
+    }
+  }
+
+  // Check the custom function registry for dynamically loaded plugins.
+  {
+    auto& registry = sparqlExpression::CustomFunctionRegistry::instance();
+    std::string_view fullIri = asStringViewUnsafe(iri.getContent());
+    if (const auto* entry = registry.lookup(fullIri)) {
+      if (static_cast<int>(argList.size()) != entry->arity) {
+        reportError(
+            ctx, absl::StrCat("Custom function ", iri.toStringRepresentation(),
+                              " expects ", std::to_string(entry->arity),
+                              " argument(s)"));
+      }
+      return entry->factory(std::move(argList));
     }
   }
 


### PR DESCRIPTION
Allow loading custom SPARQL functions at server startup via `--load-plugin path.so`, enabling users to extend QLever with functions without modifying the main codebase.

I guess having the custom functions for knowledge graph inside QLever is not practical and not what we want (conflicts, maintenance, ...). Making it possible to load custom functions solves this trade-off. Still we might want to bundle some of the most common functions or provide them as a separate package (think `qlever-functions-wikidata`).