### PR TITLE
Cleanup Native Build

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -49,8 +49,6 @@ jobs:
           - compiler: clang
             compiler-version: 13
           - compiler: clang
-            compiler-version: 15
-          - compiler: clang
             compiler-version: 16
             isPr: true
           - compiler: clang

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gcc, clang]
-        compiler-version: [8, 11, 12, 13, 18, 21]
+        compiler-version: [11, 12, 13, 18, 21]
         warnings: [  "-Wall -Wextra -Werror " ]
         build-type: [Release]
         expensive-tests: [true]
@@ -36,16 +36,12 @@ jobs:
         skipIfPr: [false]
         exclude:
           - compiler: gcc
-            compiler-version: 8
-          - compiler: gcc
             compiler-version: 12
             isPr: true
           - compiler: gcc
             compiler-version: 18
           - compiler: gcc
             compiler-version: 21
-          - compiler: clang
-            compiler-version: 8
           - compiler: clang
             compiler-version: 11
           - compiler: clang

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -49,9 +49,6 @@ jobs:
           - compiler: clang
             compiler-version: 13
           - compiler: clang
-            compiler-version: 16
-            isPr: true
-          - compiler: clang
             compiler-version: 18
             isPr: true
         include:


### PR DESCRIPTION
Compilers used during packaging:

- Bookworm (EOL, but still LTS): gcc 12
- Trixie: gcc 14 
- 22.04/Jammy: gcc 11
- 24.04/Noble: gcc 13
- 25.04/Plucky (EOL): gcc 14
- 25.10/Questing (EOL): gcc 15
- 26.04/Resolute: gcc 15